### PR TITLE
fix: upgrade deps?

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -21,11 +21,11 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.16.1"
 dependencies:
-- name: redis
-  version: 15.3.2
-  repository: https://charts.bitnami.com/bitnami
-- name: postgresql
-  version: 10.10.3
-  repository: https://charts.bitnami.com/bitnami
+  - name: redis
+    version: 17.0.4
+    repository: https://charts.bitnami.com/bitnami
+  - name: postgresql
+    version: 11.6.18
+    repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
### What was wrong?

Something is wrong with the build (shown here https://console.cloud.google.com/cloud-build/builds/77b7193f-108e-44b9-9d9d-269cdf873070;step=1?project=clabs-gnosis-safe)

### How was it fixed?

Trying to upgrade dependencies to something more recent.
